### PR TITLE
Add concatmap, An inlined version of the composition (concat . map).

### DIFF
--- a/src/lib/CFStream_stream.ml
+++ b/src/lib/CFStream_stream.ml
@@ -332,6 +332,30 @@ let concat xs =
   in
   from aux
 
+let concatmap l ~f =
+  let rec find_next_non_empty_stream xs =
+    (* As opposed to concat, we use next here to avoid infinite looping. *)
+    match next xs with
+      | Some x ->
+          let stream = f x in
+          if is_empty stream then
+            find_next_non_empty_stream xs
+          else Some stream
+      | None -> None
+  in
+  let current = ref (empty ()) in
+  let aux _ =
+    match next !current with
+      | None -> (
+          match find_next_non_empty_stream l with
+            | None -> None
+            | Some stream ->
+                current := stream ;
+                next stream
+        )
+      | x -> x
+  in
+  from aux
 
 let combine (xs, ys) =
   let aux _ =

--- a/src/lib/CFStream_stream.mli
+++ b/src/lib/CFStream_stream.mli
@@ -306,6 +306,7 @@ val filter : 'a t -> f:('a -> bool) -> 'a t
 val filter_map : 'a t -> f:('a -> 'b option) -> 'b t
 val append : 'a t -> 'a t -> 'a t
 val concat : 'a t t -> 'a t
+val concatmap : 'a t -> f:('a -> 'b t) -> 'b t
 
 val combine : 'a t * 'b t -> ('a * 'b) t
 (** [combine] transforms a pair of streams into a stream of pairs of


### PR DESCRIPTION
See this mail for motivating benchmarks : https://lists.forge.ocamlcore.org/pipermail/batteries-devel/2014-January/001924.html.

I hope it's consistent with the rest of the library, I'm not used to Core's style.
