### PR TITLE
bugfix of `drop` (also fixes `skip`)

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@ CFStream Release Notes
 
 cfstream-1.1.2 2014-06-16
 -------------------------
+* bugfix on `drop` and `skip`
 * Reduced deps to core_kernel instead of core.
 
 cfstream-1.1.1 2014-03-02

--- a/src/lib/CFStream_stream.ml
+++ b/src/lib/CFStream_stream.ml
@@ -156,7 +156,8 @@ let rec drop_whilei xs ~f =
 let drop_while xs ~f = drop_whilei xs ~f:(const f)
 
 let drop xs ~n =
-  drop_whilei xs ~f:(fun j _ -> j < n)
+  let i = ref n in
+  drop_whilei xs ~f:(fun _ _ -> if !i > 0 then (decr i ; true) else false)
 
 let skip_whilei xs ~f =
   drop_whilei xs ~f ;


### PR DESCRIPTION
The implementation of `drop` was plain wrong, provoking this kind of
problem:

``` ocaml
# let s = Stream.of_list [ 1 ; 2 ; 3 ];;
val s : int Stream.t = <abstr>
# Stream.next s;;
- : int option = Some 1
# Stream.next s;;
- : int option = Some 2
# Stream.drop s 1;;
- : unit = ()
# Stream.next s;;
- : int option = Some 3
```
