### PR TITLE
skip now returns the stream in input instead of fresh one

### DIFF
--- a/src/lib/CFStream_stream.ml
+++ b/src/lib/CFStream_stream.ml
@@ -161,13 +161,13 @@ let drop xs ~n =
 
 let skip_whilei xs ~f =
   drop_whilei xs ~f ;
-  from (fun _ -> next xs)
+  xs
 
 let skip_while xs ~f = skip_whilei xs ~f:(const f)
 
 let skip xs ~n =
   drop xs ~n ;
-  from (fun _ -> next xs)
+  xs
 
 let span xs ~f =
     (*Two possibilities: either the tail has been read

--- a/src/lib/CFStream_stream.mli
+++ b/src/lib/CFStream_stream.mli
@@ -256,11 +256,8 @@ val drop : 'a t -> n:int -> unit
     and stops when [f] evals to false on the head element. *)
 val drop_while : 'a t -> f:('a -> bool) -> unit
 
-(** Similar to [drop] but returns a fresh stream obtained after
-    discarding the [n] first elements. Being a fresh stream, the count
-    of the returned stream starts from 0. Beware though, that the
-    input and output streams are consuminmg the same resource, so
-    consuming one modify the other. *)
+(** Similar to [drop] but returns the stream in input (useful in
+    chained composition). *)
 val skip : 'a t -> n:int -> 'a t
 
 (** Similar to [skip]: [skip_while xs ~f] removes elements from [xs]


### PR DESCRIPTION
Pros:
- with the previous version, skipping many elements ended up in
  stack overflow
- with a fresh stream, the counter is set to zero, which has no real
  benefit in practice
