### PR TITLE
all functions: access error-free stream and stay in the error monad

### DIFF
--- a/src/lib/CFStream_stream.ml
+++ b/src/lib/CFStream_stream.ml
@@ -587,6 +587,17 @@ module Result = struct
   type ('a, 'b) t = ('a, 'b) Result.t Stream.t
 
   module Impl = struct
+
+    let all_gen (type e) g (xs : ('a, e) t) ~f =
+      let module M = struct exception E of e end in
+      let error_to_exn e = M.E e in
+      try g (f (result_to_exn xs ~error_to_exn))
+      with M.E e -> Result.Error e
+
+    let all xs ~f = all_gen ident xs ~f
+
+    let all' xs ~f = all_gen (fun x -> Ok x) xs ~f
+
     let to_exn = result_to_exn
 
     let map' rs ~f =

--- a/src/lib/CFStream_stream.mli
+++ b/src/lib/CFStream_stream.mli
@@ -380,6 +380,10 @@ val result_to_exn :
 module Result : sig
   type ('a, 'e) t = ('a, 'e) Result.t Stream.t
 
+  val all : ('a, 'e) t -> f:('a Stream.t -> ('b, 'e) Result.t) -> ('b, 'e) Result.t
+
+  val all' : ('a, 'e) t -> f:('a Stream.t -> 'b) -> ('b, 'e) Result.t
+
   val to_exn : ('a, 'e) t -> error_to_exn:('e -> exn) -> 'a Stream.t
 
   val map : ('a, 'e) t -> f:('a -> ('b, 'e) Result.t) -> ('b,'e) t
@@ -409,6 +413,10 @@ end
     Or_error.t] *)
 module Or_error : sig
   type 'a t = 'a Or_error.t Stream.t
+
+  val all : 'a t -> f:('a Stream.t -> 'b Or_error.t) -> 'b Or_error.t
+
+  val all' : 'a t -> f:('a Stream.t -> 'b) -> 'b Or_error.t
 
   val to_exn : 'a t -> error_to_exn:(Error.t -> exn) -> 'a Stream.t
 


### PR DESCRIPTION
This is a more pleasant alternative to `to_exn` functions.
