### PR TITLE
Standardize the bash shebang line

### DIFF
--- a/bin/git_commit.sh
+++ b/bin/git_commit.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 # Print git commit to stdout in OCaml notation.
 


### PR DESCRIPTION
The real fix is to add the `!`, but I think this is the standard calling convention in case the OS places `bash` somewhere non-standard.