### PR TITLE
Add support for OCaml 5.0

### DIFF
--- a/app/cfstream_test.ml
+++ b/app/cfstream_test.ml
@@ -139,14 +139,14 @@ let test_scan () =
 
 let test_merge () =
   let rnd_list () =
-    List.(init 20 ~f:(fun _ -> Random.int 1000) |> sort ~compare:Pervasives.compare)
+    List.(init 20 ~f:(fun _ -> Random.int 1000) |> sort ~compare:Stdlib.compare)
   in
   let f _ =
     let left = rnd_list ()
     and right = rnd_list () in
-    let gold = List.sort ~compare:Pervasives.compare (left @ right)
+    let gold = List.sort ~compare:Stdlib.compare (left @ right)
     and merged =
-      merge (of_list left) (of_list right) ~cmp:Pervasives.compare |> to_list
+      merge (of_list left) (of_list right) ~cmp:Stdlib.compare |> to_list
     in
     assert_equal
       ~printer:int_list_printer

--- a/cfstream.opam
+++ b/cfstream.opam
@@ -14,10 +14,13 @@ authors: [
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
 
 depends: [
   "ocaml" {>= "4.04.1"}
-  "dune"
+  "dune" {>= "1.0"}
   "core_kernel" {>= "v0.11.0"}
   "camlp-streams" {>= "5.0.1"}
   "ounit" {with-test}

--- a/cfstream.opam
+++ b/cfstream.opam
@@ -19,5 +19,6 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "dune"
   "core_kernel" {>= "v0.11.0"}
+  "camlp-streams" {>= "5.0.1"}
   "ounit" {with-test}
 ]

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name CFStream)
  (public_name cfstream)
- (libraries core_kernel)
+ (libraries core_kernel camlp-streams)
  (synopsis "Stream operations in the style of Core's API.")
 )
 


### PR DESCRIPTION
This library uses the `Stream` module which has been moved to a new `camlp-streams` library.